### PR TITLE
Update to FHIR ^0.12.0

### DIFF
--- a/demos/deviceauthdemo/pubspec.yaml
+++ b/demos/deviceauthdemo/pubspec.yaml
@@ -6,10 +6,10 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  fhir: ^0.11.4
+  fhir: ^0.12.0
   # fhir:
   #   path: ../../../fhir
-  fhir_at_rest: ^0.11.4
+  fhir_at_rest: ^0.12.0
   # fhir_at_rest:
   #   path: ../../../fhir_at_rest
   fhir_auth:
@@ -18,8 +18,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  google_sign_in: ^6.1.5
-  http: ^1.1.0
+  google_sign_in: ^6.2.1
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/demos/ehrlaunchdemo/pubspec.yaml
+++ b/demos/ehrlaunchdemo/pubspec.yaml
@@ -6,10 +6,10 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  fhir: ^0.11.0
+  fhir: ^0.12.0
   # fhir:
   #   path: ../../../fhir
-  fhir_at_rest: ^0.11.0
+  fhir_at_rest: ^0.12.0
   # fhir_at_rest: 
   #   path: ../../../fhir_at_rest
   fhir_auth:

--- a/demos/webauthdemo/pubspec.yaml
+++ b/demos/webauthdemo/pubspec.yaml
@@ -6,10 +6,10 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  fhir: ^0.11.4
+  fhir: ^0.12.0
   # fhir:
   #   path: ../../../fhir
-  fhir_at_rest: ^0.11.4
+  fhir_at_rest: ^0.12.0
   # fhir_at_rest:
   #   path: ../../../fhir_at_rest
   fhir_auth:
@@ -18,12 +18,12 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  google_sign_in: ^6.1.5
+  google_sign_in: ^6.2.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lints: ^2.1.1
+  lints: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/lib/fhir_client/authenticate/device_authentication.dart
+++ b/lib/fhir_client/authenticate/device_authentication.dart
@@ -17,20 +17,26 @@ class DeviceAuthentication implements BaseAuthentication {
     required Uri authorizationUrl,
     required FhirUri redirectUri,
   }) async {
-    if (['android', 'ios'].contains(defaultTargetPlatform.name)) {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      // Android specific flag
       return await FlutterWebAuth2.authenticate(
-        callbackUrlScheme: redirectUri.value!.scheme,
-        url: authorizationUrl.toString(),
-        preferEphemeral: true,
-      );
-    } else {
-      if (['linux', 'macos', 'windows'].contains(defaultTargetPlatform.name)) {
-        return await FlutterWebAuth2.authenticate(
           callbackUrlScheme: redirectUri.value!.scheme,
           url: authorizationUrl.toString(),
-          preferEphemeral: true,
-        );
-      }
+          options: FlutterWebAuth2Options(
+            // Android specific flag
+            intentFlags: ephemeralIntentFlags,
+          ));
+    } else if (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS) {
+      // iOS and macOS specific flag
+      return await FlutterWebAuth2.authenticate(
+          callbackUrlScheme: redirectUri.value!.scheme,
+          url: authorizationUrl.toString(),
+          options: FlutterWebAuth2Options(
+            // iOS and macOS specific flag
+            preferEphemeral: true,
+          ));
+    } else {
       throw UnsupportedError(
           'Cannot authenticate without dart:html or dart:io.');
     }

--- a/lib/fhir_client/authenticate/web_authentication.dart
+++ b/lib/fhir_client/authenticate/web_authentication.dart
@@ -33,7 +33,7 @@ class WebAuthentication implements BaseAuthentication {
 
       return messageEvt.data;
     } catch (e, stack) {
-      return 'Failed with Exception:$e\nHere is the Stack: $stack';
+      throw Exception('Exception: $e\nStack: $stack');
     }
   }
 }

--- a/lib/fhir_client/gcp_fhir_client.dart
+++ b/lib/fhir_client/gcp_fhir_client.dart
@@ -44,8 +44,7 @@ class GcpFhirClient extends SecureFhirClient {
         await _googleSignIn.signIn();
       }
     } catch (e, stack) {
-      log('Exception: $e');
-      log('Stack at time of Exception: \n$stack');
+      throw Exception('Exception: $e\nStack: $stack');
     }
   }
 

--- a/lib/fhir_client/smart_fhir_client.dart
+++ b/lib/fhir_client/smart_fhir_client.dart
@@ -233,8 +233,7 @@ class SmartFhirClient extends SecureFhirClient {
         email = grant.fhirParameters['email'];
         profile = grant.fhirParameters['profile'];
       } catch (e, stack) {
-        log('Exception: $e');
-        log('Stack: $stack');
+        throw Exception('Exception: $e\nStack: $stack');
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   crypto: ^3.0.3
   collection: ^1.18.0
-  fhir: ^0.11.4
+  fhir: ^0.12.0
   # fhir:
   #   path: ../fhir
   flutter:
@@ -20,11 +20,11 @@ dependencies:
   flutter_web_auth_2: ^3.1.1
   freezed_annotation: ^2.4.1
   google_sign_in: ^6.2.1
-  http: ^1.2.0
+  http: ^1.2.1
   http_parser: ^4.0.2
   jwt_decoder: ^2.0.1
   oauth2: ^2.0.2
-  url_launcher: ^6.2.4
+  url_launcher: ^6.2.5
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_web_auth_2: ^3.1.1
+  flutter_web_auth_2: ^4.0.0-alpha.2
   freezed_annotation: ^2.4.1
   google_sign_in: ^6.2.1
   http: ^1.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fhir_auth
 description: A Dart/Flutter package for authorization & authentication, includes SMART on FHIR and Google sign-in
-version: 0.11.0-dev.2
+version: 0.12.0
 homepage: https://www.fhirfli.dev/
 repository: https://github.com/MayJuun/fhir/tree/main/fhir_auth
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_web_auth_2: ^2.2.1
+  flutter_web_auth_2: ^3.0.4
   freezed_annotation: ^2.4.1
   google_sign_in: ^6.1.5
   http: ^1.1.0
@@ -28,7 +28,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.6
-  flutter_lints: ^2.0.3
+  flutter_lints: ^3.0.1
   freezed: ^2.4.5
   import_sorter: ^4.6.0
   test: ^1.24.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fhir_auth
 description: A Dart/Flutter package for authorization & authentication, includes SMART on FHIR and Google sign-in
-version: 0.11.0-dev.1
+version: 0.11.0-dev.2
 homepage: https://www.fhirfli.dev/
 repository: https://github.com/MayJuun/fhir/tree/main/fhir_auth
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.3
-  collection: ^1.17.1
+  collection: ^1.18.0
   fhir: ^0.11.4
   # fhir:
   #   path: ../fhir
@@ -17,18 +17,18 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_web_auth_2: ^3.0.4
+  flutter_web_auth_2: ^3.1.1
   freezed_annotation: ^2.4.1
-  google_sign_in: ^6.1.5
-  http: ^1.1.0
+  google_sign_in: ^6.2.1
+  http: ^1.2.0
   http_parser: ^4.0.2
   jwt_decoder: ^2.0.1
   oauth2: ^2.0.2
-  url_launcher: ^6.1.14
+  url_launcher: ^6.2.4
 
 dev_dependencies:
-  build_runner: ^2.4.6
+  build_runner: ^2.4.8
   flutter_lints: ^3.0.1
-  freezed: ^2.4.5
+  freezed: ^2.4.7
   import_sorter: ^4.6.0
-  test: ^1.24.8
+  test: ^1.25.2


### PR DESCRIPTION
The current version of `fhir_auth` doesn't support the latest version of FHIR (^0.12.0). This PR updates to the latest version of FHIR, and addresses the breaking changes seen in upgrading to `flutter_web_auth_2` to v3.x. The biggest change is to update the preferEphemeral flag to something specific for Android (intent flags) and for iOS / macOS (preferEphemeral boolean).